### PR TITLE
Add deskpro-ui styles imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,5 @@
+import "@deskpro/deskpro-ui/dist/deskpro-ui.css";
+import "@deskpro/deskpro-ui/dist/deskpro-custom-icons.css";
 import { DeskproAppProvider } from "@deskpro/app-sdk";
 import * as React from "react";
 import { Main } from "./pages/Main";


### PR DESCRIPTION
Added imports for deskpro-ui styles

There are 2 imports 
 - `import "@deskpro/deskpro-ui/dist/deskpro-ui.css";`
   - This import includes the fonts used by deskpro-ui components
 - `import "@deskpro/deskpro-ui/dist/deskpro-custom-icons.css";`
   - This includes the cutom deskpro fonts that are used by the Icon component