### PR TITLE
[Security] Fix 'Unpinned tag for a non-immutable Action in workflow'

### DIFF
--- a/.github/workflows/branch_build.yml
+++ b/.github/workflows/branch_build.yml
@@ -167,3 +167,9 @@ jobs:
           method: "POST"
           customHeaders: '{"Content-Type": "application/json", "x-api-key": "${{ secrets.APP_REGISTRY_KEY }}"}'
           data: '{"repositoryUrl": "${{ github.server_url }}/${{ github.repository }}"}'
+
+  release:
+    uses: DeskproApps/app-template-vite/.github/workflows/subworkflow-release.yml@master
+    secrets: inherit
+    needs: [deskpro_app_test_and_build]
+

--- a/.github/workflows/subworkflow-release.yml
+++ b/.github/workflows/subworkflow-release.yml
@@ -3,10 +3,15 @@ name: "Release to App Marketplace"
 on:
   workflow_call:
     inputs:
-      ref:
+      server_url:
         type: string
-        description: "The commit ref to build"
-        default: ${{ github.ref }}
+        description: "The URL of the GitHub server URL."
+        default: ${{ github.server_url }}
+        required: false
+      repository:
+        type: string
+        description: "The owner and repository name to release."
+        default: ${{ github.server_url }}
         required: false
 
     secrets:
@@ -26,7 +31,7 @@ jobs:
           curl -X POST \
             -H "Content-Type: application/json" \
             -H "x-api-key: ${{ secrets.APP_REGISTRY_KEY }}" \
-            -d '{"repositoryUrl": "'${{ github.server_url }}/${{ github.repository }}', "type": "github""}' \
+            -d '{"repositoryUrl": "'${{ inputs.server_url }}/${{ inputs.repository }}', "type": "github""}' \
             https://apps.deskpro-service.com/register
 
       - name: Trigger release
@@ -34,5 +39,5 @@ jobs:
           curl -X POST \
             -H "Content-Type: application/json" \
             -H "x-api-key: ${{ secrets.APP_REGISTRY_KEY }}" \
-            -d '{"repositoryUrl": "'${{ github.server_url }}/${{ github.repository }}'"}' \
+            -d '{"repositoryUrl": "'${{ inputs.server_url }}/${{ inputs.repository }}'"}' \
             https://apps.deskpro-service.com/release

--- a/.github/workflows/subworkflow-release.yml
+++ b/.github/workflows/subworkflow-release.yml
@@ -1,0 +1,38 @@
+name: "Release to App Marketplace"
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        description: "The commit ref to build"
+        default: ${{ github.ref }}
+        required: false
+
+    secrets:
+      APP_REGISTRY_KEY: { required: true }
+
+jobs:
+  release:
+    name: Release App
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: Register release with apps registry
+        id: register_with_apps_registry
+        run: |
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: ${{ secrets.APP_REGISTRY_KEY }}" \
+            -d '{"repositoryUrl": "'${{ github.server_url }}/${{ github.repository }}', "type": "github""}' \
+            https://apps.deskpro-service.com/register
+
+      - name: Trigger release
+        run: |
+          curl -X POST \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: ${{ secrets.APP_REGISTRY_KEY }}" \
+            -d '{"repositoryUrl": "'${{ github.server_url }}/${{ github.repository }}'"}' \
+            https://apps.deskpro-service.com/release


### PR DESCRIPTION
This addresses [Unpinned tag for a non-immutable Action in workflow](https://github.com/DeskproApps/sellsy/security/code-scanning/7) which gets reported by Github. This resolves the issue by using vanilla CURL instead of a 3rd party Action (as we're not doing anything fancy). I've also made it into a subworkflow so other repos can just point to this one so we can update them all in one go if we need to (same thing happens for deploys already so this is just reusing that function but for releases).