### PR TITLE
Improve Error Reporting for Apps Sentry [sc-65330]

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,10 @@
     "@deskpro/app-sdk": "^6.0.6",
     "@deskpro/deskpro-ui": "^8.3.1",
     "@heroicons/react": "1.0.6",
+    "@sentry/react": "^9.22.0",
     "@tanstack/react-query": "^4.36.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-error-boundary": "^4.1.2",
     "react-is": "^18.3.1",
     "react-router-dom": "^6.30.0",
     "styled-components": "^6.1.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@heroicons/react':
         specifier: 1.0.6
         version: 1.0.6(react@18.3.1)
+      '@sentry/react':
+        specifier: ^9.22.0
+        version: 9.22.0(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^4.36.1
         version: 4.36.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -26,9 +29,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      react-error-boundary:
-        specifier: ^4.1.2
-        version: 4.1.2(react@18.3.1)
       react-is:
         specifier: ^18.3.1
         version: 18.3.1
@@ -934,6 +934,36 @@ packages:
     resolution: {integrity: sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA==}
     cpu: [x64]
     os: [win32]
+
+  '@sentry-internal/browser-utils@9.22.0':
+    resolution: {integrity: sha512-Ou1tBnVxFAIn8i9gvrWzRotNJQYiu3awNXpsFCw6qFwmiKAVPa6b13vCdolhXnrIiuR77jY1LQnKh9hXpoRzsg==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/feedback@9.22.0':
+    resolution: {integrity: sha512-zgMVkoC61fgi41zLcSZA59vOtKxcLrKBo1ECYhPD1hxEaneNqY5fhXDwlQBw96P5l2yqkgfX6YZtSdU4ejI9yA==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay-canvas@9.22.0':
+    resolution: {integrity: sha512-EcG9IMSEalFe49kowBTJObWjof/iHteDwpyuAszsFDdQUYATrVUtwpwN7o52vDYWJud4arhjrQnMamIGxa79eQ==}
+    engines: {node: '>=18'}
+
+  '@sentry-internal/replay@9.22.0':
+    resolution: {integrity: sha512-9GOycoKbrclcRXfcbNV8svbmAsOS5R4wXBQmKF4pFLkmFA/lJv9kdZSNYkRvkrxdNfbMIJXP+DV9EqTZcryXig==}
+    engines: {node: '>=18'}
+
+  '@sentry/browser@9.22.0':
+    resolution: {integrity: sha512-3TeRm74dvX0JdjX0AgkQa+22iUHwHnY+Q6M05NZ+tDeCNHGK/mEBTeqquS1oQX67jWyuvYmG3VV6RJUxtG9Paw==}
+    engines: {node: '>=18'}
+
+  '@sentry/core@9.22.0':
+    resolution: {integrity: sha512-ixvtKmPF42Y6ckGUbFlB54OWI75H2gO5UYHojO6eXFpS7xO3ZGgV/QH6wb40mWK+0w5XZ0233FuU9VpsuE6mKA==}
+    engines: {node: '>=18'}
+
+  '@sentry/react@9.22.0':
+    resolution: {integrity: sha512-mI43NnioBYdG5TiXqRlhV1feZs9bnrrl+k5HOHBK7VQtymaXO0fkcsRLZTkdSgLRLMJGasZuvVhq2xK+18QyWQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.14.0 || 17.x || 18.x || 19.x
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -2636,11 +2666,6 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
-  react-error-boundary@4.1.2:
-    resolution: {integrity: sha512-GQDxZ5Jd+Aq/qUxbCm1UtzmL/s++V7zKgE8yMktJiCQXCCFZnMZh9ng+6/Ne6PjNSXH0L9CjeOEREfRnq6Duag==}
-    peerDependencies:
-      react: '>=16.13.1'
-
   react-fast-compare@2.0.4:
     resolution: {integrity: sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==}
 
@@ -4082,6 +4107,41 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.40.2':
     optional: true
+
+  '@sentry-internal/browser-utils@9.22.0':
+    dependencies:
+      '@sentry/core': 9.22.0
+
+  '@sentry-internal/feedback@9.22.0':
+    dependencies:
+      '@sentry/core': 9.22.0
+
+  '@sentry-internal/replay-canvas@9.22.0':
+    dependencies:
+      '@sentry-internal/replay': 9.22.0
+      '@sentry/core': 9.22.0
+
+  '@sentry-internal/replay@9.22.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 9.22.0
+      '@sentry/core': 9.22.0
+
+  '@sentry/browser@9.22.0':
+    dependencies:
+      '@sentry-internal/browser-utils': 9.22.0
+      '@sentry-internal/feedback': 9.22.0
+      '@sentry-internal/replay': 9.22.0
+      '@sentry-internal/replay-canvas': 9.22.0
+      '@sentry/core': 9.22.0
+
+  '@sentry/core@9.22.0': {}
+
+  '@sentry/react@9.22.0(react@18.3.1)':
+    dependencies:
+      '@sentry/browser': 9.22.0
+      '@sentry/core': 9.22.0
+      hoist-non-react-statics: 3.3.2
+      react: 18.3.1
 
   '@sinclair/typebox@0.27.8': {}
 
@@ -6086,11 +6146,6 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
-
-  react-error-boundary@4.1.2(react@18.3.1):
-    dependencies:
-      '@babel/runtime': 7.27.1
-      react: 18.3.1
 
   react-fast-compare@2.0.4: {}
 

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,0 +1,14 @@
+import * as Sentry from "@sentry/react";
+
+const urlParams = new URLSearchParams(document.location.search);
+const sentryDsn = urlParams.get('_sentry_dsn');
+const sentryTunnel = urlParams.get('_sentry_tunnel') || undefined;
+
+if (sentryDsn) {
+  Sentry.init({
+    dsn: sentryDsn,
+    sendDefaultPii: false,
+    tunnel: sentryTunnel,
+    integrations: [],
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,25 +1,28 @@
+import "./instrument";
 import { StrictMode, Suspense } from "react";
 import ReactDOM from "react-dom/client";
 import { HashRouter } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
-import { ErrorBoundary } from "react-error-boundary";
 import { DeskproAppProvider, LoadingSpinner } from "@deskpro/app-sdk";
 import { queryClient } from "@/query";
 import "@deskpro/deskpro-ui/dist/deskpro-ui.css";
 import "@deskpro/deskpro-ui/dist/deskpro-custom-icons.css";
 import "./main.css";
 import { App } from "./App";
+import * as Sentry from "@sentry/react";
 
-const root = ReactDOM.createRoot(document.getElementById('root') as Element);
+const root = ReactDOM.createRoot(document.getElementById('root') as Element, {
+  onRecoverableError: Sentry.reactErrorHandler(),
+});
 root.render((
   <StrictMode>
     <DeskproAppProvider>
       <HashRouter>
         <QueryClientProvider client={queryClient}>
           <Suspense fallback={<LoadingSpinner/>}>
-            <ErrorBoundary fallback={<>here was an error!</>}>
+            <Sentry.ErrorBoundary fallback={<>here was an error!</>}>
               <App />
-            </ErrorBoundary>
+            </Sentry.ErrorBoundary>
           </Suspense>
         </QueryClientProvider>
       </HashRouter>

--- a/src/pages/Main/Main.tsx
+++ b/src/pages/Main/Main.tsx
@@ -40,6 +40,9 @@ export const Main = () => {
   // ticket @see https://support.deskpro.com/en-US/guides/developers/targets and third party API
   return (
     <>
+      <button onClick={() => {
+        throw new Error(new Date().toISOString() + "Sentry Test Error");
+      }}>Test Sentry Error</button>
       <H1>Ticket Data</H1>
       <Stack gap={12} vertical>
         <Property label="Ticket ID" text={ticketContext.data?.ticket.id} />


### PR DESCRIPTION
This introduces Sentry as an optional feature. Parameters are passed via the query string (we cannot use app state because that happens much futher down the chain which would mean we missed any errors that happen before hand). `react-error-boundary` is replaced with Sentrys version. Also has support for tunnels via the Deskpro Instance itself.

# Evidence
![image](https://github.com/user-attachments/assets/9dc73dc1-c8d1-40db-8c6e-bb3e5270f469)

_The tunnel is reporting a 429 because we hit the rate limit for our sentry instance_